### PR TITLE
Fix panoramic images 

### DIFF
--- a/kronofoto/static/assets/css/kronofoto.css
+++ b/kronofoto/static/assets/css/kronofoto.css
@@ -536,6 +536,8 @@ main .fi-image-background{
   grid-column-end: span 6;
   display: flex;
   justify-content: center;
+  margin-left: 50%;
+  transform: translateX(-50%);
 }
 
 .fi-image figure img {


### PR DESCRIPTION
Wide images now overflow equally on both sides,  while  remaining centered